### PR TITLE
Fix new lines inserted on sqlcmd statements

### DIFF
--- a/src/languages/tsql.js
+++ b/src/languages/tsql.js
@@ -2672,7 +2672,7 @@ function(hljs) {
     },
     {
       className: 'meta',
-      begin: '^\\s*:(' +
+      begin: '^[\\t ]*:(' +
         '!!|' +
             'connect|' +
             'error|' +

--- a/test/markup/tsql/keywords.expect.txt
+++ b/test/markup/tsql/keywords.expect.txt
@@ -1,8 +1,8 @@
 <span class="hljs-comment">/*
     Hello World  <span class="hljs-comment">/* nested comment ftw */</span>
 */</span>
-<span class="hljs-meta">
-:setvar Type "TABLE"</span>
+
+<span class="hljs-meta">:setvar Type "TABLE"</span>
 
 <span class="hljs-keyword">SET</span> <span class="hljs-keyword">XACT_ABORT</span> <span class="hljs-keyword">ON</span>
 


### PR DESCRIPTION
Regex was matching newlines before the sqlcmd statements, which caused us to insert extra new lines before sqlcmd statements.

Updated test with expected behavior.